### PR TITLE
Se crea Dockerfile con 2 metodos para subir certificado y firmar XML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM php:7.2-apache
+
+RUN  mkdir /tmp/certs
+RUN chown www-data:www-data /tmp/certs
+	
+COPY hacienda /var/www/html/hacienda/
+COPY xmlseclibs /var/www/html/xmlseclibs/
+COPY signer.php /var/www/html/
+COPY cert-uploader.php /var/www/html/
+
+ENV CERTIFICATE_UPLOAD false
+
+EXPOSE 80
+
+# To build the image:
+# docker build -t php-firmador .
+
+
+# Running examples:
+#
+# Run with local directory mounted in /tmp/certs so no need to enable CERTIFICATE_UPLOAD and exposing port in localhost 8081
+# docker run --rm -d -v /home/user/certificates:/tmp/certs -p 8081:80  php-firmador:latest
+# docker run --rm -d --mount type=bind,source=/home/user/certs,destination=/tmp/certs -p 8081:80 php-firmador:latest
+
+# Run with CERTIFICATE_UPLOAD and docker's ip address pool
+# in this case you have to upload the certificate prior to signing 
+
+# docker run --rm -d  -p 8081:80 -e CERTIFICATE_UPLOAD=true web-firmador:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ EXPOSE 80
 # Run with CERTIFICATE_UPLOAD and docker's ip address pool
 # in this case you have to upload the certificate prior to signing 
 
-# docker run --rm -d  -p 8081:80 -e CERTIFICATE_UPLOAD=true web-firmador:latest
+# docker run --rm -d  -p 8081:80 -e CERTIFICATE_UPLOAD=true php-firmador:latest

--- a/cert-uploader.php
+++ b/cert-uploader.php
@@ -1,0 +1,71 @@
+<?php
+// Copyright 2019 Sergio Guzman sergio@sergioguzman.com
+//
+// This software uses firmador to sign XML from a HTTP server.
+//
+// You can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation, 
+// either version 3 of the License, or (at your option) any later version, and also under
+// the terms of xmlseclibs licensing.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// @author    2019 Sergio Guzman <sergio@sergioguzman.com>
+$enabled = false;
+if (!empty($_ENV['CERTIFICATE_UPLOAD']) and strtolower($_ENV['CERTIFICATE_UPLOAD']) == 'true') {
+	$enabled = true;
+}
+
+// Metodo de uso: hacer un POST al archivo cert-upload.php
+// el certificado debe ir en el body
+// debe enviar el nombre del archivo del certificado Request URI
+// ejemplo:
+//
+// POST http://127.0.0.1:8080/cert-uploader.php?cert=certificado.p12
+//   en el body del post debe ir el Certificado
+//   Nota -- si ya existe el certificado con ese nombre sera reemplazado
+//
+if (! $enabled) {
+	http_response_code(428); // Precondition Required
+	echo "The uploading service have not been activated by the administrator,\n";
+	echo "container must be started with environment CERTIFICATE_UPLOAD=true for this.\n";
+	exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $enabled) {
+	$urlArr = parse_url($_SERVER['REQUEST_URI']);
+	parse_str($urlArr['query'], $vars);
+
+	$pfx    = '/tmp/certs/' . $vars['cert'] ; // Ruta del archivo de la llave criptográfica (*.p12)
+	$certificate = file_get_contents('php://input'); // Certificate posted in body
+
+	http_response_code(501);
+	$dst_file = fopen($pfx, 'w');
+	if (! $dst_file ) {
+		echo "Cannot create destination file";
+		die();
+	}
+	if (fwrite($dst_file, $certificate) === FALSE) {
+		echo "Cannot write to file";
+		exit();
+	}
+	fclose($dst_file);
+
+	if (! file_exists($pfx)) { # The certificate couldn't be found in /tmp/certs
+		http_response_code(412); // Precondition Failed
+		print "The certificate could not be written.";
+		exit();
+	}
+
+	http_response_code(201);
+} else {
+	http_response_code(405); # Method not allowed
+	print "Method not allowed";
+}
+

--- a/signer.php
+++ b/signer.php
@@ -1,0 +1,80 @@
+<?php
+// Copyright 2019 Sergio Guzman sergio@sergioguzman.com
+//
+// This software uses firmador to sign XML from a HTTP server.
+//
+// You can redistribute it and/or modify it under the terms of the
+// GNU Affero General Public License as published by the Free Software Foundation, 
+// either version 3 of the License, or (at your option) any later version, and also under
+// the terms of xmlseclibs licensing.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// @author    2019 Sergio Guzman <sergio@sergioguzman.com>
+require(dirname(__FILE__) . '/hacienda/firmador.php');
+
+use Hacienda\Firmador;
+$firmador = new Firmador();
+
+// Metodo de uso: hacer un POST al archivo signer.php
+// el XML debe ir en el body ya sea en BASE64 encoded o no
+// debe enviar el nombre del archivo del certificado el pin del mismo en el Request URI
+// ejemplo:
+//
+// POST http://127.0.0.1:8080/signer.php?cert=certificado.p12&pin=1111
+//   en el body del post debe ir el XML
+// 
+// -- Nota previo a utilizar este archivo se debe haber hecho un POST a cert-upload.php
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+	$urlArr = parse_url($_SERVER['REQUEST_URI']);
+	parse_str($urlArr['query'], $vars);
+
+	$pfx    = '/tmp/certs/' . $vars['cert'] ; // Ruta del archivo de la llave criptográfica (*.p12)
+
+	if (! file_exists($pfx)) { # The certificate couldn't be found in /tmp/certs
+		http_response_code(412); // Precondition Failed
+		print "The certificate is not found here, please send the certificate and try again.";
+		exit();
+	}
+
+	$pin    = $vars['pin']; // PIN de 4 dígitos de la llave criptográfica
+	if (empty($pin) or empty($pfx)) {
+		http_response_code(400);  // bad request
+		print "Incomplete request";
+		exit();
+	}
+	if (strlen($pin) < 4) {
+		http_response_code(400);  // bad request
+		print "Pin length must be greater than or equal to 4.";
+		exit();
+	}
+
+	$xml = file_get_contents('php://input'); // XML posted in body
+
+	$is_base64 = false;
+	if (!preg_match('%\<?xml%', $xml)) { // very simple detection
+		$is_base64 = true;
+		$xml = base64_decode($xml);
+	}
+
+	if (!preg_match('%\<?xml%', $xml)) {
+		http_response_code(400);  // bad request
+		print "File does not appear to be a XML\n";
+		exit();
+	}
+
+	$base64 = $firmador->firmarXml($pfx, $pin, $xml, $firmador::TO_BASE64_STRING);
+	http_response_code(200);
+	print_r($base64);
+} else {
+	http_response_code(405); # Method not allowed
+	print "Method not allowed";
+}
+


### PR DESCRIPTION
Se crea un dockerfile para ejecutar el firmador desde un servidor apache y dos metodos: uno para subir el certificado y otro para firmar XMLs. 

Para crear la imagen y como utilizarla ver el archivo Dockerfile
Para uso de los dos metodos:
 cert-uploader.php (Se debe activar mediante variable de ambiente)
 signer.php (necesita el certificado accesible en /tmp/certs)

/tmp/certs es creado en la imagen y se monta con -v al momento de crear la instancia de docker
o se activa la variable de ambiente CERTIFICATE_UPLOAD=true para permitir subir certificados y posterior uso.